### PR TITLE
- Added Advertisement callback to update device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 target/
 .mypy_cache/
 .ropeproject/
+
+# PyCharme
+*.idea

--- a/Adafruit_BluefruitLE/corebluetooth/adapter.py
+++ b/Adafruit_BluefruitLE/corebluetooth/adapter.py
@@ -55,6 +55,7 @@ class CoreBluetoothAdapter(Adapter):
         self._is_scanning = False
         self._powered_on = threading.Event()
         self._powered_off = threading.Event()
+        self._adv_callbabk = None
 
     def _state_changed(self, state):
         """Called when the power state changes."""
@@ -74,10 +75,11 @@ class CoreBluetoothAdapter(Adapter):
         # Mac OSX has no oncept of BLE adapters so just return a fixed value.
         return "Default Adapter"
 
-    def start_scan(self, timeout_sec=TIMEOUT_SEC):
+    def start_scan(self, timeout_sec=TIMEOUT_SEC, callback=None):
         """Start scanning for BLE devices."""
         get_provider()._central_manager.scanForPeripheralsWithServices_options_(None, None)
         self._is_scanning = True
+        self._adv_callbabk = callback
 
     def stop_scan(self, timeout_sec=TIMEOUT_SEC):
         """Stop scanning for BLE devices."""

--- a/Adafruit_BluefruitLE/corebluetooth/device.py
+++ b/Adafruit_BluefruitLE/corebluetooth/device.py
@@ -50,18 +50,24 @@ class CoreBluetoothDevice(Device):
         self._discovered = threading.Event()
         self._rssi_read = threading.Event()
 
+        # callback to update disconnection
+        self._disconnection_callback = None
+
     @property
     def _central_manager(self):
         # Lookup the CBCentralManager, reduces verbosity of calls.
         return get_provider()._central_manager
 
-    def connect(self, timeout_sec=TIMEOUT_SEC):
+    def connect(self, timeout_sec=TIMEOUT_SEC, disconnection_callback=None):
         """Connect to the device.  If not connected within the specified timeout
         then an exception is thrown.
         """
         self._central_manager.connectPeripheral_options_(self._peripheral, None)
         if not self._connected.wait(timeout_sec):
             raise RuntimeError('Failed to connect to device within timeout period!')
+
+        if disconnection_callback is not None:
+            self._disconnection_callback = disconnection_callback
 
     def disconnect(self, timeout_sec=TIMEOUT_SEC):
         """Disconnect from the device.  If not disconnected within the specified
@@ -90,6 +96,10 @@ class CoreBluetoothDevice(Device):
         """Set the connected event."""
         self._connected.clear()
         self._disconnected.set()
+
+        # update disconnection to callback function
+        if self._disconnection_callback is not None:
+            self._disconnection_callback()
 
     def _update_advertised(self, advertised):
         """Called when advertisement data is received."""

--- a/Adafruit_BluefruitLE/platform.py
+++ b/Adafruit_BluefruitLE/platform.py
@@ -22,17 +22,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import sys
+import logging
 
 
 # Keep a single global instance of the BLE provider.
 _provider = None
 
 
-def get_provider():
+def get_provider(log_level=logging.DEBUG):
     """Return an instance of the BLE provider for the current platform."""
     global _provider
     # Set the provider based on the current platform.
     if _provider is None:
+        if log_level not in [logging.DEBUG, logging.INFO]:
+            log_level = logging.DEBUG
+
         if sys.platform.startswith('linux'):
             # Linux platform
             from .bluez_dbus.provider import BluezProvider
@@ -40,7 +44,7 @@ def get_provider():
         elif sys.platform == 'darwin':
             # Mac OSX platform
             from .corebluetooth.provider import CoreBluetoothProvider
-            _provider = CoreBluetoothProvider()
+            _provider = CoreBluetoothProvider(log_level)
         else:
             # Unsupported platform
             raise RuntimeError('Sorry the {0} platform is not supported by the BLE library!'.format(sys.platform))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import platform
 platform_install_requires = []
 
 if platform.system() == 'Darwin':
-    platform_install_requires += ['pyobjc-framework-CoreBluetooth']
+    platform_install_requires += ['pyobjc-framework-CoreBluetooth', 'pyobjc-framework-libdispatch']
 
 # To use a consistent encoding
 from codecs import open
@@ -17,12 +17,12 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name              = 'Adafruit_BluefruitLE',
-      version           = '0.9.10',
-      author            = 'Tony DiCola',
-      author_email      = 'tdicola@adafruit.com',
+      version           = '0.10.0',
+      author            = 'Hardik Prajapati',
+      author_email      = 'hardik@infocusp.in',
       description       = 'Python library for interacting with Bluefruit LE (Bluetooth low energy) devices on Linux or OSX.',
       long_description  = long_description,
       license           = 'MIT',
-      url               = 'https://github.com/adafruit/Adafruit_Python_BluefruitLE/',
+      url               = 'https://github.com/hardik-prajapati/Adafruit_Python_BluefruitLE/',
       install_requires  = ['future'] + platform_install_requires,
       packages          = find_packages())


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Added support for advertisement callbacks in the BLE adapter and provider, allowing users to receive device updates during scanning.
- Introduced a disconnection callback mechanism in the BLE device class, enabling user notification when a device disconnects unexpectedly.
- Added the ability to set the logging level for BLE operations, improving debugging and log management.
- Refactored the CoreBluetooth provider to use a background thread for the event loop and a dispatch queue for CoreBluetooth initialization, enhancing thread safety and responsiveness.
- Improved logging granularity for BLE events by using `logger.info` for key connection and discovery events.
- Updated the setup script to include `pyobjc-framework-libdispatch` as a dependency for macOS and refreshed package metadata.

This PR enhances the BLE library's flexibility and robustness by introducing callback mechanisms for advertisement and disconnection events, improving logging control, and ensuring better event loop management. These changes make the library more suitable for responsive and production-grade BLE applications.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>provider.py</strong><dd><code>Add callbacks, logging level, and threaded event loop to CoreBluetooth <br>provider</code></dd></summary>
<hr>

Adafruit_BluefruitLE/corebluetooth/provider.py
<li>Added support for setting logging level in <code>CentralDelegate</code> and <br><code>CoreBluetoothProvider</code>.<br> <li> Introduced advertisement callback invocation in <br><code>centralManager_didDiscoverPeripheral_advertisementData_RSSI_</code>.<br> <li> Replaced direct AppHelper event loop with a new <code>EventLoopThread</code> class <br>to run the event loop in a background thread.<br> <li> Added dispatch queue (<code>libdispatch</code>) for CoreBluetooth initialization.<br> <li> Improved logging (using <code>logger.info</code> for key BLE events).<br> <li> Refactored <code>run_mainloop_with</code> to use the new threaded event loop.<br>


</details>


  </td>
  <td><a href="https://github.com/fungusmungos/Adafruit_Python_BluefruitLE/pull/1/files#diff-84fe1fc77d2e8613fe236622eac0d23ca5163b9b64eae3ae120f11c7a5d25353">+43/-18</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Add advertisement callback support to BLE adapter scan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adafruit_BluefruitLE/corebluetooth/adapter.py
<li>Added support for an advertisement callback in <code>start_scan</code>.<br> <li> Stored the callback for use during device discovery.<br>


</details>


  </td>
  <td><a href="https://github.com/fungusmungos/Adafruit_Python_BluefruitLE/pull/1/files#diff-6cf68c1ea0f8cdceabddbef1223a5d2797247a8a27d4ff3d432a79c43a569f25">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>device.py</strong><dd><code>Add disconnection callback support to BLE device connection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adafruit_BluefruitLE/corebluetooth/device.py
<li>Added support for a disconnection callback in <code>connect</code>.<br> <li> Invoked the disconnection callback in <code>_set_disconnected</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/fungusmungos/Adafruit_Python_BluefruitLE/pull/1/files#diff-1e91003b24d0d7e77737d5192e24a7ffde008d47282f8d41d917345360751123">+11/-1</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>platform.py</strong><dd><code>Allow setting logging level when getting BLE provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adafruit_BluefruitLE/platform.py
<li>Modified <code>get_provider</code> to accept and propagate a logging level <br>parameter.<br> <li> Ensured logging level is set appropriately for CoreBluetoothProvider.<br>


</details>


  </td>
  <td><a href="https://github.com/fungusmungos/Adafruit_Python_BluefruitLE/pull/1/files#diff-b11a415ddf478c0300f018d297995072d776b0fe986badf594efa3f9c1806c3b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Update setup metadata and add libdispatch dependency for macOS</code>&nbsp; </dd></summary>
<hr>

setup.py
<li>Added <code>pyobjc-framework-libdispatch</code> as a dependency for macOS.<br> <li> Updated package metadata: version, author, author email, and URL.<br>


</details>


  </td>
  <td><a href="https://github.com/fungusmungos/Adafruit_Python_BluefruitLE/pull/1/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
